### PR TITLE
Support more collections from the std lib, remove unused dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,3 @@ description = "Library to calculate TF-IDF (Term Frequency - Inverse Document Fr
 name = "tfidf"
 
 [dependencies]
-num = "0.1.*"

--- a/src/idf.rs
+++ b/src/idf.rs
@@ -130,3 +130,25 @@ fn idf_wiki_example_tests() {
   assert_eq!(UnaryIdf::idf("this", docs.iter()), 1f64);
   assert_eq!(InverseFrequencyIdf::idf("this", docs.iter()), 0f64);
 }
+
+#[test]
+fn idf_wiki_example_tests_hashmap() {
+  let mut docs: Vec<std::collections::HashMap<&'static str, usize>> = Vec::new();
+
+  docs.push(vec![("this", 1), ("is", 1), ("a", 2), ("sample", 1)].into_iter().collect());
+  docs.push(vec![("this", 1), ("is", 1), ("another", 2), ("example", 3)].into_iter().collect());
+
+  assert_eq!(UnaryIdf::idf("this", docs.iter()), 1f64);
+  assert_eq!(InverseFrequencyIdf::idf("this", docs.iter()), 0f64);
+}
+
+#[test]
+fn idf_wiki_example_tests_btreemap() {
+  let mut docs: Vec<std::collections::BTreeMap<&'static str, usize>> = Vec::new();
+
+  docs.push(vec![("this", 1), ("is", 1), ("a", 2), ("sample", 1)].into_iter().collect());
+  docs.push(vec![("this", 1), ("is", 1), ("another", 2), ("example", 3)].into_iter().collect());
+
+  assert_eq!(UnaryIdf::idf("this", docs.iter()), 1f64);
+  assert_eq!(InverseFrequencyIdf::idf("this", docs.iter()), 0f64);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,12 +79,12 @@
 
 #![deny(missing_docs)]
 
-extern crate num;
-
 pub use prelude::{Document, NaiveDocument, ExpandableDocument, ProcessedDocument, Tf,
                   NormalizationFactor, SmoothingFactor, TfIdf};
 
 use std::borrow::Borrow;
+use std::collections::{HashMap, BTreeMap};
+use std::hash::Hash;
 
 mod prelude;
 
@@ -128,6 +128,42 @@ impl<T> ProcessedDocument for Vec<(T, usize)> where T: PartialEq
       Some(&(ref t, _)) => Some(t),
       None => None,
     }
+  }
+}
+
+impl<T> Document for HashMap<T, usize> {
+  type Term = T;
+}
+
+impl<T> ProcessedDocument for HashMap<T, usize> where T: Eq + Hash {
+  fn term_frequency<K>(&self, term: K) -> usize where K: Borrow<Self::Term> {
+    if let Some(v) = self.get(term.borrow()) {
+      *v
+    } else {
+      0
+    }
+  }
+
+  fn max(&self) -> Option<&Self::Term> {
+    self.iter().max_by_key(|(_k, v)| *v).map(|(k, _v)| k)
+  }
+}
+
+impl<T> Document for BTreeMap<T, usize> {
+  type Term = T;
+}
+
+impl<T> ProcessedDocument for BTreeMap<T, usize> where T: Ord {
+  fn term_frequency<K>(&self, term: K) -> usize where K: Borrow<Self::Term> {
+      if let Some(v) = self.get(term.borrow()) {
+        *v
+      } else {
+        0
+      }
+  }
+
+  fn max(&self) -> Option<&Self::Term> {
+    self.iter().max_by_key(|(_k, v)| *v).map(|(k, _v)| k)
   }
 }
 


### PR DESCRIPTION
Hello @ferristseng . As suggested in the title, this PR adds support for HashMap and BTreeMap based documents.

I also noticed that `num` wasn't being used for anything, so I took that dependency out.

Cheers!